### PR TITLE
쇼핑몰 조회수 갱신에 대한 동시성 이슈 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,7 @@ dependencies {
     implementation 'com.github.gavlyukovskiy:datasource-decorator-spring-boot-autoconfigure:1.9.2'
 
     // redis
-//    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.44.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/googoo/joljol/shopping_mall/entity/ShoppingMall.java
+++ b/src/main/java/googoo/joljol/shopping_mall/entity/ShoppingMall.java
@@ -7,14 +7,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "shopping_mall")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class ShoppingMall {
 
     @Id
@@ -117,4 +116,14 @@ public class ShoppingMall {
 
     @Column(name = "monitoring_date", nullable = false)
     private LocalDate monitoringDate; // 모니터링 날짜 (필수)
+
+    public ShoppingMall(String name) {
+        this.name = name;
+        this.domain = "domain";
+        this.phone = "010-0000-000";
+        this.operatorEmail = "test@test.test";
+        this.businessStatus = "운영중";
+        this.overallRating = 3;
+        this.monitoringDate = LocalDate.now();
+    }
 }

--- a/src/main/java/googoo/joljol/shopping_mall/entity/ShoppingMallStats.java
+++ b/src/main/java/googoo/joljol/shopping_mall/entity/ShoppingMallStats.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,7 +30,10 @@ public class ShoppingMallStats {
 
     @Column(name = "view_count", nullable = false)
     private int viewCount = 0; // 조회수 초기값 0
-    
+
+    @Version
+    private Long version;
+
     public void incrementViewCount() {
         this.viewCount++;
     }

--- a/src/main/java/googoo/joljol/shopping_mall/repository/RedisLockRepository.java
+++ b/src/main/java/googoo/joljol/shopping_mall/repository/RedisLockRepository.java
@@ -1,0 +1,23 @@
+package googoo.joljol.shopping_mall.repository;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisLockRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public Boolean lock(Long key) {
+        return redisTemplate
+            .opsForValue()
+            .setIfAbsent(key.toString(), "lock", Duration.ofMillis(3_000));
+    }
+
+    public Boolean unLock(Long key) {
+        return redisTemplate.delete(key.toString());
+    }
+}

--- a/src/main/java/googoo/joljol/shopping_mall/repository/ShoppingMallStatsRepository.java
+++ b/src/main/java/googoo/joljol/shopping_mall/repository/ShoppingMallStatsRepository.java
@@ -19,4 +19,12 @@ public interface ShoppingMallStatsRepository extends JpaRepository<ShoppingMallS
           WHERE s.shoppingMall.id = :shoppingMallId
         """)
     Optional<ShoppingMallStats> findByShoppingMallIdWithPessimisticLock(Long shoppingMallId);
+
+
+    @Query("""
+          SELECT s
+          FROM ShoppingMallStats s
+          WHERE s.shoppingMall.id = :shoppingMallId
+        """)
+    Optional<ShoppingMallStats> findByShoppingMallIdWithOptimisticLock(Long shoppingMallId);
 }

--- a/src/main/java/googoo/joljol/shopping_mall/repository/ShoppingMallStatsRepository.java
+++ b/src/main/java/googoo/joljol/shopping_mall/repository/ShoppingMallStatsRepository.java
@@ -1,11 +1,22 @@
 package googoo.joljol.shopping_mall.repository;
 
 import googoo.joljol.shopping_mall.entity.ShoppingMallStats;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ShoppingMallStatsRepository extends JpaRepository<ShoppingMallStats, Long>,
     ShoppingMallStatsRepositoryCustom {
 
     Optional<ShoppingMallStats> findByShoppingMallId(Long shoppingMallId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+          SELECT s
+          FROM ShoppingMallStats s
+          WHERE s.shoppingMall.id = :shoppingMallId
+        """)
+    Optional<ShoppingMallStats> findByShoppingMallIdWithPessimisticLock(Long shoppingMallId);
 }

--- a/src/main/java/googoo/joljol/shopping_mall/service/ShoppingMallLockService.java
+++ b/src/main/java/googoo/joljol/shopping_mall/service/ShoppingMallLockService.java
@@ -9,6 +9,7 @@ import googoo.joljol.shopping_mall.repository.ShoppingMallRepository;
 import googoo.joljol.shopping_mall.repository.ShoppingMallStatsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -22,6 +23,21 @@ public class ShoppingMallLockService {
             .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
 
         ShoppingMallStats stats = shoppingMallStatsRepository.findByShoppingMallId(id)
+            .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+
+        stats.incrementViewCount();
+        shoppingMallStatsRepository.save(stats);
+
+        return shoppingMall;
+    }
+
+    @Transactional
+    public ShoppingMall getShoppingMallByIdWithPessimisticLock(Long id) {
+        ShoppingMall shoppingMall = shoppingMallRepository.findById(id)
+            .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+
+        ShoppingMallStats stats = shoppingMallStatsRepository
+            .findByShoppingMallIdWithPessimisticLock(id)
             .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
 
         stats.incrementViewCount();

--- a/src/main/java/googoo/joljol/shopping_mall/service/ShoppingMallLockService.java
+++ b/src/main/java/googoo/joljol/shopping_mall/service/ShoppingMallLockService.java
@@ -1,0 +1,32 @@
+package googoo.joljol.shopping_mall.service;
+
+import static googoo.joljol.common.exception.ExceptionType.SHOPPING_MALL_NOT_FOUND;
+
+import googoo.joljol.common.exception.CustomException;
+import googoo.joljol.shopping_mall.entity.ShoppingMall;
+import googoo.joljol.shopping_mall.entity.ShoppingMallStats;
+import googoo.joljol.shopping_mall.repository.ShoppingMallRepository;
+import googoo.joljol.shopping_mall.repository.ShoppingMallStatsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ShoppingMallLockService {
+
+    private final ShoppingMallRepository shoppingMallRepository;
+    private final ShoppingMallStatsRepository shoppingMallStatsRepository;
+
+    public synchronized ShoppingMall getShoppingMallByIdWithSynchronized(Long id) {
+        ShoppingMall shoppingMall = shoppingMallRepository.findById(id)
+            .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+
+        ShoppingMallStats stats = shoppingMallStatsRepository.findByShoppingMallId(id)
+            .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+
+        stats.incrementViewCount();
+        shoppingMallStatsRepository.save(stats);
+
+        return shoppingMall;
+    }
+}

--- a/src/main/java/googoo/joljol/shopping_mall/service/ShoppingMallService.java
+++ b/src/main/java/googoo/joljol/shopping_mall/service/ShoppingMallService.java
@@ -1,6 +1,7 @@
 package googoo.joljol.shopping_mall.service;
 
 import static googoo.joljol.common.exception.ExceptionType.SHOPPING_MALL_NOT_FOUND;
+import static googoo.joljol.common.exception.ExceptionType.SHOPPING_MALL_STATS_NOT_FOUND;
 
 import googoo.joljol.common.exception.CustomException;
 import googoo.joljol.shopping_mall.dto.ShoppingMallTop10Dto;
@@ -34,7 +35,7 @@ public class ShoppingMallService {
             .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
 
         ShoppingMallStats stats = shoppingMallStatsRepository.findByShoppingMallId(id)
-            .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(SHOPPING_MALL_STATS_NOT_FOUND));
 
         stats.incrementViewCount();
         shoppingMallStatsRepository.save(stats);

--- a/src/main/java/googoo/joljol/shopping_mall/service/lock/ShoppingMallLockService.java
+++ b/src/main/java/googoo/joljol/shopping_mall/service/lock/ShoppingMallLockService.java
@@ -1,6 +1,7 @@
 package googoo.joljol.shopping_mall.service.lock;
 
 import static googoo.joljol.common.exception.ExceptionType.SHOPPING_MALL_NOT_FOUND;
+import static googoo.joljol.common.exception.ExceptionType.SHOPPING_MALL_STATS_NOT_FOUND;
 
 import googoo.joljol.common.exception.CustomException;
 import googoo.joljol.shopping_mall.entity.ShoppingMall;
@@ -30,7 +31,7 @@ public class ShoppingMallLockService {
             .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
 
         ShoppingMallStats stats = shoppingMallStatsRepository.findByShoppingMallId(id)
-            .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(SHOPPING_MALL_STATS_NOT_FOUND));
 
         stats.incrementViewCount();
         shoppingMallStatsRepository.save(stats);
@@ -45,7 +46,7 @@ public class ShoppingMallLockService {
 
         ShoppingMallStats stats = shoppingMallStatsRepository
             .findByShoppingMallIdWithPessimisticLock(id)
-            .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(SHOPPING_MALL_STATS_NOT_FOUND));
 
         stats.incrementViewCount();
         shoppingMallStatsRepository.save(stats);
@@ -75,7 +76,7 @@ public class ShoppingMallLockService {
 
             ShoppingMallStats stats = shoppingMallStatsRepository
                 .findByShoppingMallId(id)
-                .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(SHOPPING_MALL_STATS_NOT_FOUND));
 
             stats.incrementViewCount();
             shoppingMallStatsRepository.save(stats);
@@ -99,7 +100,7 @@ public class ShoppingMallLockService {
 
                 ShoppingMallStats stats = shoppingMallStatsRepository
                     .findByShoppingMallId(id)
-                    .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+                    .orElseThrow(() -> new CustomException(SHOPPING_MALL_STATS_NOT_FOUND));
 
                 stats.incrementViewCount();
                 shoppingMallStatsRepository.save(stats);

--- a/src/main/java/googoo/joljol/shopping_mall/service/lock/ShoppingMallLockService.java
+++ b/src/main/java/googoo/joljol/shopping_mall/service/lock/ShoppingMallLockService.java
@@ -5,6 +5,7 @@ import static googoo.joljol.common.exception.ExceptionType.SHOPPING_MALL_NOT_FOU
 import googoo.joljol.common.exception.CustomException;
 import googoo.joljol.shopping_mall.entity.ShoppingMall;
 import googoo.joljol.shopping_mall.entity.ShoppingMallStats;
+import googoo.joljol.shopping_mall.repository.RedisLockRepository;
 import googoo.joljol.shopping_mall.repository.ShoppingMallRepository;
 import googoo.joljol.shopping_mall.repository.ShoppingMallStatsRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class ShoppingMallLockService {
     private final ShoppingMallRepository shoppingMallRepository;
     private final ShoppingMallStatsRepository shoppingMallStatsRepository;
     private final ShoppingMallOptimisticLockService optimisticLockService;
+    private final RedisLockRepository redisLockRepository;
 
     public synchronized ShoppingMall getShoppingMallByIdWithSynchronized(Long id) {
         ShoppingMall shoppingMall = shoppingMallRepository.findById(id)
@@ -54,6 +56,29 @@ public class ShoppingMallLockService {
             } catch (Exception e) {
                 Thread.sleep(50);
             }
+        }
+    }
+
+    @Transactional
+    public ShoppingMall getShoppingMallByIdWithLettuce(Long id) throws InterruptedException {
+        while (!redisLockRepository.lock(id)) {
+            Thread.sleep(100);
+        }
+
+        try {
+            ShoppingMall shoppingMall = shoppingMallRepository.findById(id)
+                .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+
+            ShoppingMallStats stats = shoppingMallStatsRepository
+                .findByShoppingMallId(id)
+                .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+
+            stats.incrementViewCount();
+            shoppingMallStatsRepository.save(stats);
+
+            return shoppingMall;
+        } finally {
+            redisLockRepository.unLock(id);
         }
     }
 }

--- a/src/main/java/googoo/joljol/shopping_mall/service/lock/ShoppingMallLockService.java
+++ b/src/main/java/googoo/joljol/shopping_mall/service/lock/ShoppingMallLockService.java
@@ -8,7 +8,10 @@ import googoo.joljol.shopping_mall.entity.ShoppingMallStats;
 import googoo.joljol.shopping_mall.repository.RedisLockRepository;
 import googoo.joljol.shopping_mall.repository.ShoppingMallRepository;
 import googoo.joljol.shopping_mall.repository.ShoppingMallStatsRepository;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +23,7 @@ public class ShoppingMallLockService {
     private final ShoppingMallStatsRepository shoppingMallStatsRepository;
     private final ShoppingMallOptimisticLockService optimisticLockService;
     private final RedisLockRepository redisLockRepository;
+    private final RedissonClient redissonClient;
 
     public synchronized ShoppingMall getShoppingMallByIdWithSynchronized(Long id) {
         ShoppingMall shoppingMall = shoppingMallRepository.findById(id)
@@ -79,6 +83,34 @@ public class ShoppingMallLockService {
             return shoppingMall;
         } finally {
             redisLockRepository.unLock(id);
+        }
+    }
+
+    @Transactional
+    public ShoppingMall getShoppingMallByIdWithRedisson(Long id) throws InterruptedException {
+        RLock lock = redissonClient.getLock(id.toString());
+
+        try {
+            boolean available = lock.tryLock(25, 1, TimeUnit.SECONDS);
+
+            if (available) {
+                ShoppingMall shoppingMall = shoppingMallRepository.findById(id)
+                    .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+
+                ShoppingMallStats stats = shoppingMallStatsRepository
+                    .findByShoppingMallId(id)
+                    .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+
+                stats.incrementViewCount();
+                shoppingMallStatsRepository.save(stats);
+
+                return shoppingMall;
+            }
+            return null;
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } finally {
+            lock.unlock();
         }
     }
 }

--- a/src/main/java/googoo/joljol/shopping_mall/service/lock/ShoppingMallLockService.java
+++ b/src/main/java/googoo/joljol/shopping_mall/service/lock/ShoppingMallLockService.java
@@ -1,4 +1,4 @@
-package googoo.joljol.shopping_mall.service;
+package googoo.joljol.shopping_mall.service.lock;
 
 import static googoo.joljol.common.exception.ExceptionType.SHOPPING_MALL_NOT_FOUND;
 
@@ -17,6 +17,7 @@ public class ShoppingMallLockService {
 
     private final ShoppingMallRepository shoppingMallRepository;
     private final ShoppingMallStatsRepository shoppingMallStatsRepository;
+    private final ShoppingMallOptimisticLockService optimisticLockService;
 
     public synchronized ShoppingMall getShoppingMallByIdWithSynchronized(Long id) {
         ShoppingMall shoppingMall = shoppingMallRepository.findById(id)
@@ -44,5 +45,15 @@ public class ShoppingMallLockService {
         shoppingMallStatsRepository.save(stats);
 
         return shoppingMall;
+    }
+
+    public ShoppingMall getShoppingMallByIdWithOptimisticLock(Long id) throws InterruptedException {
+        while (true) {
+            try {
+                return optimisticLockService.callOptimisticLock(id);
+            } catch (Exception e) {
+                Thread.sleep(50);
+            }
+        }
     }
 }

--- a/src/main/java/googoo/joljol/shopping_mall/service/lock/ShoppingMallOptimisticLockService.java
+++ b/src/main/java/googoo/joljol/shopping_mall/service/lock/ShoppingMallOptimisticLockService.java
@@ -1,0 +1,36 @@
+package googoo.joljol.shopping_mall.service.lock;
+
+import static googoo.joljol.common.exception.ExceptionType.SHOPPING_MALL_NOT_FOUND;
+
+import googoo.joljol.common.exception.CustomException;
+import googoo.joljol.shopping_mall.entity.ShoppingMall;
+import googoo.joljol.shopping_mall.entity.ShoppingMallStats;
+import googoo.joljol.shopping_mall.repository.ShoppingMallRepository;
+import googoo.joljol.shopping_mall.repository.ShoppingMallStatsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ShoppingMallOptimisticLockService {
+
+    private final ShoppingMallRepository shoppingMallRepository;
+    private final ShoppingMallStatsRepository shoppingMallStatsRepository;
+
+    @Transactional
+    public ShoppingMall callOptimisticLock(Long id) {
+        ShoppingMall shoppingMall = shoppingMallRepository.findById(id)
+            .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+
+        ShoppingMallStats stats = shoppingMallStatsRepository
+            .findByShoppingMallIdWithOptimisticLock(id)
+            .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+
+        stats.incrementViewCount();
+        shoppingMallStatsRepository.save(stats);
+
+        return shoppingMall;
+    }
+
+}

--- a/src/main/java/googoo/joljol/shopping_mall/service/lock/ShoppingMallOptimisticLockService.java
+++ b/src/main/java/googoo/joljol/shopping_mall/service/lock/ShoppingMallOptimisticLockService.java
@@ -1,6 +1,7 @@
 package googoo.joljol.shopping_mall.service.lock;
 
 import static googoo.joljol.common.exception.ExceptionType.SHOPPING_MALL_NOT_FOUND;
+import static googoo.joljol.common.exception.ExceptionType.SHOPPING_MALL_STATS_NOT_FOUND;
 
 import googoo.joljol.common.exception.CustomException;
 import googoo.joljol.shopping_mall.entity.ShoppingMall;
@@ -25,7 +26,7 @@ public class ShoppingMallOptimisticLockService {
 
         ShoppingMallStats stats = shoppingMallStatsRepository
             .findByShoppingMallIdWithOptimisticLock(id)
-            .orElseThrow(() -> new CustomException(SHOPPING_MALL_NOT_FOUND));
+            .orElseThrow(() -> new CustomException(SHOPPING_MALL_STATS_NOT_FOUND));
 
         stats.incrementViewCount();
         shoppingMallStatsRepository.save(stats);

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: false
+        format_sql: false
+        dialect: org.hibernate.dialect.H2Dialect

--- a/src/test/java/googoo/joljol/sync_test/ShoppingMallLockServiceTest.java
+++ b/src/test/java/googoo/joljol/sync_test/ShoppingMallLockServiceTest.java
@@ -145,4 +145,29 @@ class ShoppingMallLockServiceTest {
             .orElseThrow();
         assertThat(stats.getViewCount()).isEqualTo(100);
     }
+
+    @Test
+    void 조회수_100개_동시에_증가_Redisson() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    shoppingMallService.getShoppingMallByIdWithRedisson(shoppingMallId);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        ShoppingMallStats stats = shoppingMallStatsRepository.findByShoppingMallId(shoppingMallId)
+            .orElseThrow();
+        assertThat(stats.getViewCount()).isEqualTo(100);
+    }
 }

--- a/src/test/java/googoo/joljol/sync_test/ShoppingMallLockServiceTest.java
+++ b/src/test/java/googoo/joljol/sync_test/ShoppingMallLockServiceTest.java
@@ -72,4 +72,27 @@ class ShoppingMallLockServiceTest {
             .orElseThrow();
         assertThat(stats.getViewCount()).isEqualTo(100);
     }
+
+    @Test
+    void 조회수_100개_동시에_증가_PessimisticLock() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    shoppingMallService.getShoppingMallByIdWithPessimisticLock(shoppingMallId);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        ShoppingMallStats stats = shoppingMallStatsRepository.findByShoppingMallId(shoppingMallId)
+            .orElseThrow();
+        assertThat(stats.getViewCount()).isEqualTo(100);
+    }
 }

--- a/src/test/java/googoo/joljol/sync_test/ShoppingMallLockServiceTest.java
+++ b/src/test/java/googoo/joljol/sync_test/ShoppingMallLockServiceTest.java
@@ -1,0 +1,75 @@
+package googoo.joljol.sync_test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import googoo.joljol.shopping_mall.entity.ShoppingMall;
+import googoo.joljol.shopping_mall.entity.ShoppingMallStats;
+import googoo.joljol.shopping_mall.repository.ShoppingMallRepository;
+import googoo.joljol.shopping_mall.repository.ShoppingMallStatsRepository;
+import googoo.joljol.shopping_mall.service.ShoppingMallLockService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+// Synchronized, 비관락, 낙관락, 네임드락, 분산락 적용하여 테스트
+@SpringBootTest
+@ActiveProfiles("test")
+class ShoppingMallLockServiceTest {
+
+    @Autowired
+    private ShoppingMallLockService shoppingMallService;
+
+    @Autowired
+    private ShoppingMallStatsRepository shoppingMallStatsRepository;
+
+    @Autowired
+    private ShoppingMallRepository shoppingMallRepository;
+
+    private Long shoppingMallId = 1L;
+
+    @BeforeEach
+    public void before() {
+        ShoppingMall shoppingMall = new ShoppingMall("test");
+        shoppingMallRepository.saveAndFlush(shoppingMall);
+        shoppingMallId = shoppingMall.getId();
+        ShoppingMallStats shoppingMallStats = new ShoppingMallStats();
+        ReflectionTestUtils.setField(shoppingMallStats, "shoppingMall", shoppingMall);
+        shoppingMallStatsRepository.saveAndFlush(shoppingMallStats);
+    }
+
+    @AfterEach
+    public void after() {
+        shoppingMallStatsRepository.deleteAll();
+        shoppingMallRepository.deleteAll();
+    }
+
+    @Test
+    void 조회수_100개_동시에_증가_Synchronized() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    shoppingMallService.getShoppingMallByIdWithSynchronized(shoppingMallId);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        ShoppingMallStats stats = shoppingMallStatsRepository.findByShoppingMallId(shoppingMallId)
+            .orElseThrow();
+        assertThat(stats.getViewCount()).isEqualTo(100);
+    }
+}

--- a/src/test/java/googoo/joljol/sync_test/ShoppingMallLockServiceTest.java
+++ b/src/test/java/googoo/joljol/sync_test/ShoppingMallLockServiceTest.java
@@ -120,4 +120,29 @@ class ShoppingMallLockServiceTest {
             .orElseThrow();
         assertThat(stats.getViewCount()).isEqualTo(100);
     }
+
+    @Test
+    void 조회수_100개_동시에_증가_Lettuce() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    shoppingMallService.getShoppingMallByIdWithLettuce(shoppingMallId);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        ShoppingMallStats stats = shoppingMallStatsRepository.findByShoppingMallId(shoppingMallId)
+            .orElseThrow();
+        assertThat(stats.getViewCount()).isEqualTo(100);
+    }
 }

--- a/src/test/java/googoo/joljol/sync_test/ShoppingMallLockServiceTest.java
+++ b/src/test/java/googoo/joljol/sync_test/ShoppingMallLockServiceTest.java
@@ -6,7 +6,7 @@ import googoo.joljol.shopping_mall.entity.ShoppingMall;
 import googoo.joljol.shopping_mall.entity.ShoppingMallStats;
 import googoo.joljol.shopping_mall.repository.ShoppingMallRepository;
 import googoo.joljol.shopping_mall.repository.ShoppingMallStatsRepository;
-import googoo.joljol.shopping_mall.service.ShoppingMallLockService;
+import googoo.joljol.shopping_mall.service.lock.ShoppingMallLockService;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -83,6 +83,31 @@ class ShoppingMallLockServiceTest {
             executorService.submit(() -> {
                 try {
                     shoppingMallService.getShoppingMallByIdWithPessimisticLock(shoppingMallId);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        ShoppingMallStats stats = shoppingMallStatsRepository.findByShoppingMallId(shoppingMallId)
+            .orElseThrow();
+        assertThat(stats.getViewCount()).isEqualTo(100);
+    }
+
+    @Test
+    void 조회수_100개_동시에_증가_OptimisticLock() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    shoppingMallService.getShoppingMallByIdWithOptimisticLock(shoppingMallId);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
                 } finally {
                     latch.countDown();
                 }

--- a/src/test/java/googoo/joljol/sync_test/ShoppingMallServiceTest.java
+++ b/src/test/java/googoo/joljol/sync_test/ShoppingMallServiceTest.java
@@ -1,0 +1,85 @@
+package googoo.joljol.sync_test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import googoo.joljol.shopping_mall.entity.ShoppingMall;
+import googoo.joljol.shopping_mall.entity.ShoppingMallStats;
+import googoo.joljol.shopping_mall.repository.ShoppingMallRepository;
+import googoo.joljol.shopping_mall.repository.ShoppingMallStatsRepository;
+import googoo.joljol.shopping_mall.service.ShoppingMallService;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+// Lock 적용하지 않은 초기 코드 테스트
+@SpringBootTest
+@ActiveProfiles("test")
+class ShoppingMallServiceTest {
+
+    @Autowired
+    private ShoppingMallService shoppingMallService;
+
+    @Autowired
+    private ShoppingMallStatsRepository shoppingMallStatsRepository;
+
+    @Autowired
+    private ShoppingMallRepository shoppingMallRepository;
+
+    private Long shoppingMallId = 1L;
+
+    @BeforeEach
+    public void before() {
+        ShoppingMall shoppingMall = new ShoppingMall("test");
+        shoppingMallRepository.saveAndFlush(shoppingMall);
+        shoppingMallId = shoppingMall.getId();
+        ShoppingMallStats shoppingMallStats = new ShoppingMallStats();
+        ReflectionTestUtils.setField(shoppingMallStats, "shoppingMall", shoppingMall);
+        shoppingMallStatsRepository.saveAndFlush(shoppingMallStats);
+    }
+
+    @AfterEach
+    public void after() {
+        shoppingMallStatsRepository.deleteAll();
+        shoppingMallRepository.deleteAll();
+    }
+
+    @Test
+    void 조회수_1_증가() {
+        shoppingMallService.getShoppingMallById(shoppingMallId);
+
+        ShoppingMallStats stats = shoppingMallStatsRepository.findByShoppingMallId(shoppingMallId)
+            .orElseThrow();
+
+        assertThat(stats.getViewCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 조회수_100개_동시에_증가() throws InterruptedException {
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    shoppingMallService.getShoppingMallById(shoppingMallId);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        ShoppingMallStats stats = shoppingMallStatsRepository.findByShoppingMallId(shoppingMallId)
+            .orElseThrow();
+        assertThat(stats.getViewCount()).isEqualTo(100);
+    }
+}


### PR DESCRIPTION
### 구현 사항

- 쇼핑몰 동시 100개 조회시 동시성 이슈 생기는 테스트 코드 작성
- synchronized로 동시성 해결
- 비관락으로 동시성 이슈 해결
- 낙관락으로 동시성 이슈 해결
- 분산락 Lettuce로 동시성 이슈 해결
- 분산락 Redisson으로 동시성 이슈 해결

### 속도 비교

(느림) synchronized < Lettuce < Redisson < OptimisticLock < PessimisticLock (빠름)

<img width="630" alt="스크린샷 2025-02-04 오후 7 52 56" src="https://github.com/user-attachments/assets/88d6b2e1-de1f-4b7f-b727-0491c7fc4044" />

[결론]
=> 동시성 문제가 많이 생기는 경우의 테스트 코드를 작성했기 때문에, 비관락이 가장 빨랐습니다. DB를 여러대 두는 경우를 고려해 Redis 사용을 고려할 수 있는데, 이 경우 Lettuce보다 Redisson이 더 효율적이었습니다.
